### PR TITLE
bump react-native-menu to fix android builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@config-plugins/react-native-dynamic-app-icon": "^2.0.0",
         "@expo/vector-icons": "^14.0.0",
         "@react-native-async-storage/async-storage": "1.23.1",
-        "@react-native-menu/menu": "^0.9.1",
+        "@react-native-menu/menu": "^1.1.5",
         "@react-navigation/bottom-tabs": "^6.5.8",
         "@react-navigation/native": "^6.1.10",
         "@react-navigation/native-stack": "^6.9.13",
@@ -6194,10 +6194,9 @@
       }
     },
     "node_modules/@react-native-menu/menu": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@react-native-menu/menu/-/menu-0.9.1.tgz",
-      "integrity": "sha512-PdZoN1P72ESQ7UTzm5YI4W+87KU5mv7vVJ3GsQVRtnrzzuVskfp5E9ds1biGClcTieXAdIZ7hvPD1HHHZPobdg==",
-      "license": "MIT",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@react-native-menu/menu/-/menu-1.1.7.tgz",
+      "integrity": "sha512-TPu2iNrSK1Davw5BPhwzcSfMAI9NFggiISOgdlaeymA6L7aAjUGpsEaFVX+ZaHml/YtZUuC8U0zUJJc2/3VYAA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@config-plugins/react-native-dynamic-app-icon": "^2.0.0",
     "@expo/vector-icons": "^14.0.0",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-menu/menu": "^0.9.1",
+    "@react-native-menu/menu": "^1.1.5",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native": "^6.1.10",
     "@react-navigation/native-stack": "^6.9.13",


### PR DESCRIPTION
Android builds were failing, saw https://github.com/react-native-menu/menu/issues/945#issuecomment-2441421958 and builds now work after using react-native-menu 1.1.5