### PR TITLE
Fix infinite loading on Card Info screen for inactive cards

### DIFF
--- a/src/pages/card.tsx
+++ b/src/pages/card.tsx
@@ -243,9 +243,9 @@ export default function CardPage({
         </View>
       )}
 
-      {transactionsLoading || transactions === undefined ? (
+      {transactionsLoading ? (
         <ActivityIndicator />
-      ) : transactions.data.length == 0 ? (
+      ) :  transactions === undefined || transactions.data.length == 0  ? (
         <Text
           style={{
             color: palette.muted,
@@ -254,7 +254,7 @@ export default function CardPage({
             textAlign: "center",
           }}
         >
-          No purchases on this card yet.
+          There are no purchases on this card.
         </Text>
       ) : (
         <>

--- a/src/pages/card.tsx
+++ b/src/pages/card.tsx
@@ -245,7 +245,7 @@ export default function CardPage({
 
       {transactionsLoading ? (
         <ActivityIndicator />
-      ) :  transactions === undefined || transactions.data.length == 0  ? (
+      ) : transactions === undefined || transactions.data.length === 0 ? (
         <Text
           style={{
             color: palette.muted,


### PR DESCRIPTION
## Summary of the problem

The app displayed an infinite loading spinner on the Card Info screen when viewing inactive cards with no transaction data. This happened because the API sometimes returns undefined instead of an empty list, and the UI did not handle this case properly.

## Describe your changes

- Added a check for undefined transaction data to avoid infinite loading.
- Updated the feedback message to: “There are no purchases on this card.”
This is clearer and now applies to both undefined and empty transaction arrays.

## Checklist

- [x ] Descriptive PR title
- [x ] Tag related issues so they auto-close on merge
- [x ] Easily digestible commits [video](https://gist.github.com/garyhtou/97534180b0753aa607c35b6fdda9d2e0)
- [x ] CI passes 
- [x ] Tested by submitter before requesting review 

![image](https://github.com/user-attachments/assets/586b3876-11f0-4703-9688-8fecdcf23d1f)
