### PR TITLE
Fix GeoPatterns mismatch by implementing custom pattern library (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ EXPO_PUBLIC_CLIENT_ID=<uid field from the Doorkeeper app>
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md).
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "expo-system-ui": "~4.0.6",
         "expo-updates": "^0.26.19",
         "expo-web-browser": "~14.0.1",
-        "geopattern": "github:thedev132/geopattern",
+        "hcb-geo-pattern": "^1.0.1",
         "humanize-string": "^3.0.0",
         "ky": "^1.2.3",
         "lodash": "^4.17.21",
@@ -5713,6 +5713,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-convert": "*"
+      }
+    },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -6899,28 +6923,6 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {
@@ -10619,14 +10621,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/geopattern": {
-      "version": "1.2.3",
-      "resolved": "git+ssh://git@github.com/thedev132/geopattern.git#01c242d8af19ecf924f666b15cd9d518fad20e7b",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "object-assign": "^4.1.0"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
@@ -10917,6 +10911,42 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hcb-geo-pattern": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hcb-geo-pattern/-/hcb-geo-pattern-1.0.1.tgz",
+      "integrity": "sha512-mzfXflfp4GFDsOfUsP3IxwCai4pyIYbGK6cN0SS+53UVFjpJd/lsLoSw3ccTEjjWlpL+SOeb6rwEfl8NN7RoOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/color": "^3.0.1",
+        "color": "^3.1.2",
+        "tiny-sha1": "^0.2.1"
+      }
+    },
+    "node_modules/hcb-geo-pattern/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/hcb-geo-pattern/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/hcb-geo-pattern/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.23.1",
@@ -16431,6 +16461,16 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tiny-sha1": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-sha1/-/tiny-sha1-0.2.1.tgz",
+      "integrity": "sha512-g16ybryknNVIr4Qt02a6Z/IAqqTz2DG2AQPe6KxKn2RP5ISH7pa5foWwQBGW444g1aBmN7wSGoouZsY5kILNjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0",
+        "npm": ">=2.14.2"
       }
     },
     "node_modules/tmp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@react-navigation/native-stack": "^6.9.13",
         "@stripe/stripe-terminal-react-native": "^0.0.1-beta.20",
         "@thedev132/hackclub-icons-rn": "^0.0.14",
+        "buffer": "^6.0.3",
         "date-fns": "^2.30.0",
         "eas-cli": "^13.4.2",
         "expo": "^52.0.23",
@@ -6923,6 +6924,30 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-alloc": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/native-stack": "^6.9.13",
     "@stripe/stripe-terminal-react-native": "^0.0.1-beta.20",
     "@thedev132/hackclub-icons-rn": "^0.0.14",
+    "buffer": "^6.0.3",
     "date-fns": "^2.30.0",
     "eas-cli": "^13.4.2",
     "expo": "^52.0.23",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "expo-system-ui": "~4.0.6",
     "expo-updates": "^0.26.19",
     "expo-web-browser": "~14.0.1",
-    "geopattern": "github:thedev132/geopattern",
+    "hcb-geo-pattern": "^1.0.1",
     "humanize-string": "^3.0.0",
     "ky": "^1.2.3",
     "lodash": "^4.17.21",

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,3 +55,15 @@ export function redactedCardNumber(last4?: string) {
 export function renderCardNumber(number: string) {
   return words(number, /\d{4}/g).join(" ");
 }
+
+export const normalizeSvg = (
+  svg: string,
+  width: number,
+  height: number,
+  scaleFactor: number = 1.25,
+): string => {
+  return svg.replace(
+    "<svg",
+    `<svg preserveAspectRatio="xMinYMin slice" viewBox="0 0 ${width / scaleFactor} ${height / scaleFactor}"`,
+  );
+};


### PR DESCRIPTION
## Summary of the problem

The card patterns on the HCB website were inconsistent with those in the app. 

## Describe your changes

The problem was resolved by:

1. Switching to a [TypeScript port of GeoPattern](https://github.com/mooyoul/geo-pattern), customized to support grayscale rendering, and publishing it to both [NPM](https://www.npmjs.com/package/hcb-geo-pattern) and [GitHub](https://github.com/rocristoi/hcb-geo-pattern) for transparency.
2. Adding a utility function in util.ts called `normalizeSvg`  to normalize SVG dimensions, which is now used for all generated SVGs.

## Checklist

- [ x ] Descriptive PR title _(Does the title explain the changes in a concise manner?)_
- [ x ] Tag related issues so they auto-close on merge
- [ x ] Easily digestible commits _(Are the commits small and easy to understand?)_ [video](https://gist.github.com/garyhtou/97534180b0753aa607c35b6fdda9d2e0)
- [ x ] CI passes _(Do the GitHub checks pass?)_
- [ x ] Tested by submitter before requesting review _(Does it work in development iOS/android? )_

![image (6) (1)](https://github.com/user-attachments/assets/14bc9a59-a3db-49cf-9a68-9cef34c61a28)

![image (5)](https://github.com/user-attachments/assets/16b8ca94-9262-4a15-9f07-8b0bb3718731)
