### PR TITLE
Add deep linking disable feature in settings

### DIFF
--- a/src/LinkingContext.tsx
+++ b/src/LinkingContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const LinkingContext = createContext<{
+  enabled: boolean;
+  setEnabled: (val: boolean) => void;
+}>({
+  enabled: true,
+  setEnabled: () => {},
+});
+
+export const LinkingProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const val = await AsyncStorage.getItem("linking-enabled");
+      setEnabled(val !== "false");
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem("linking-enabled", enabled ? "true" : "false");
+  }, [enabled]);
+
+  return (
+    <LinkingContext.Provider value={{ enabled, setEnabled }}>
+      {children}
+    </LinkingContext.Provider>
+  );
+};
+
+export const useLinkingPref = () => useContext(LinkingContext);

--- a/src/Navigator.tsx
+++ b/src/Navigator.tsx
@@ -30,6 +30,7 @@ import ReceiptsPage from "./pages/Receipts";
 import RenameTransactionPage from "./pages/RenameTransaction";
 import About from "./pages/settings/About";
 import AppIconSelector from "./pages/settings/AppIconSelector";
+import DeepLinkingSettings from "./pages/settings/DeepLinkingSettings";
 import SettingsPage from "./pages/settings/Settings";
 import Tutorials from "./pages/settings/Tutorials";
 import TransactionPage from "./pages/Transaction";
@@ -260,6 +261,11 @@ export default function Navigator() {
               name="AppIconSelector"
               component={AppIconSelector}
               options={{ title: "App Icon" }}
+            />
+            <SettingsStack.Screen
+              name="DeepLinkingSettings"
+              component={DeepLinkingSettings}
+              options={{ title: "Deep Linking" }}
             />
             <SettingsStack.Screen
               name="Tutorials"

--- a/src/lib/NavigatorParamList.ts
+++ b/src/lib/NavigatorParamList.ts
@@ -53,6 +53,7 @@ export type TabParamList = {
 export type SettingsStackParamList = {
   SettingsMain: undefined;
   AppIconSelector: undefined;
+  DeepLinkingSettings: undefined;
   Tutorials: undefined;
   About: undefined;
 };

--- a/src/pages/settings/DeepLinkingSettings.tsx
+++ b/src/pages/settings/DeepLinkingSettings.tsx
@@ -1,0 +1,71 @@
+import { Switch, View, Text, ScrollView } from "react-native";
+import { palette } from "../../theme";
+import { useLinkingPref } from "../../LinkingContext";
+import { useTheme } from "@react-navigation/native";
+
+export default function DeepLinkingSettings() {
+  const { enabled, setEnabled } = useLinkingPref();
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={{ backgroundColor: colors.background, padding: 32 }}
+    >
+      <View style={{ width: "100%" }}>
+        <View
+          style={{
+            width: "100%",
+            backgroundColor: colors.card,
+            padding: 20,
+            borderRadius: 16,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 4 },
+            shadowOpacity: 0.18,
+            shadowRadius: 6.0,
+            elevation: 6,
+            marginVertical: 16,
+          }}
+        >
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 12,
+            }}
+          >
+            <Text
+              style={{
+                color: palette.primary,
+                fontSize: 18,
+                fontWeight: "600",
+                letterSpacing: 0.2,
+              }}
+            >
+              Open links in app
+            </Text>
+            <Switch
+              trackColor={{ false: "#767577", true: palette.primary }}
+              thumbColor="#f4f3f4"
+              ios_backgroundColor="#3e3e3e"
+              onValueChange={() => setEnabled(!enabled)}
+              value={enabled}
+            />
+          </View>
+          <Text
+            style={{
+              color: "#888",
+              fontSize: 14,
+              marginTop: 8,
+              lineHeight: 20,
+            }}
+          >
+            Deep links allow you to open supported links directly inside this
+            app, instead of your browser. When enabled, tapping a compatible
+            link will take you straight to the relevant screen here.
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -257,6 +257,35 @@ export default function SettingsPage({ navigation }: Props) {
               style={{ marginLeft: "auto" }}
             />
           </Pressable>
+          <View
+            style={{
+              height: 1,
+              backgroundColor: dividerColor,
+              marginLeft: 20,
+              marginRight: 20,
+            }}
+          />
+          <Pressable
+            style={{ flexDirection: "row", alignItems: "center", padding: 18 }}
+            onPress={() => navigation.navigate("DeepLinkingSettings")}
+          >
+            <Ionicons
+              name="link"
+              size={22}
+              color={palette.muted}
+              style={{ marginRight: 12 }}
+            />
+            <Text style={{ color: colors.text, fontSize: 16 }}>
+              Deep linking
+            </Text>
+            <Ionicons
+              name="chevron-forward"
+              size={20}
+              color={palette.muted}
+              style={{ marginLeft: "auto" }}
+            />
+          </Pressable>
+
           {showTutorials && (
             <>
               <View


### PR DESCRIPTION
## Summary of the problem

The problem was that some users don't like the automatic opening of HCB links in app.

## Describe your changes

This update introduces a new slider in the settings, allowing users to choose whether links should open within the app or in their default browser. When users opt out of HCB deep linking, the app now redirects them to the original destination URL accordingly.

Due to the OS-level nature of iOS Universal Links, it's not possible to completely disable deep linking via a simple setting. However, this implementation includes a clever workaround: if deep linking is disabled, the app briefly opens before automatically redirecting the user to their intended destination. While this does result in a momentary display of the app, the trade-off is worthwhile for the improved user experience.

## Checklist

- [x] Descriptive PR title _(Does the title explain the changes in a concise manner?)_
- [x] Tag related issues so they auto-close on merge
- [x] Easily digestible commits _(Are the commits small and easy to understand?)_ [video](https://gist.github.com/garyhtou/97534180b0753aa607c35b6fdda9d2e0)
- [x] CI passes _(Do the GitHub checks pass?)_
- [x] Tested by submitter before requesting review _(Does it work in development iOS/android? )_


https://github.com/user-attachments/assets/52c89825-8795-4f00-97f0-edec9bdede43

