### PR TITLE
Fix theme readability and loading

### DIFF
--- a/src/Navigator.tsx
+++ b/src/Navigator.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { BlurView } from "expo-blur";
 import * as WebBrowser from "expo-web-browser";
-import { StyleSheet, useColorScheme } from "react-native";
+import { StyleSheet } from "react-native";
 import useSWR, { useSWRConfig } from "swr";
 
 import {
@@ -16,6 +16,7 @@ import {
 } from "./lib/NavigatorParamList";
 import { PaginatedResponse } from "./lib/types/HcbApiObject";
 import Invitation from "./lib/types/Invitation";
+import { useIsDark } from "./lib/useColorScheme";
 import CardPage from "./pages/card";
 import CardsPage from "./pages/cards";
 import Home from "./pages/index";
@@ -34,7 +35,6 @@ import SettingsPage from "./pages/settings/Settings";
 import Tutorials from "./pages/settings/Tutorials";
 import TransactionPage from "./pages/Transaction";
 import { palette } from "./theme";
-import { useThemeContext } from "./ThemeContext";
 
 // import OrganizationTitle from "./components/organizations/OrganizationTitle";
 
@@ -54,10 +54,7 @@ export default function Navigator() {
   const { colors: themeColors } = useTheme();
 
   const { mutate } = useSWRConfig();
-  const { theme: themePref } = useThemeContext();
-  const colorScheme = useColorScheme();
-  const isDark =
-    themePref === "dark" || (themePref === "system" && colorScheme === "dark");
+  const isDark = useIsDark();
 
   return (
     <Tab.Navigator

--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -14,11 +14,13 @@ const THEME_KEY = "app_theme";
 interface ThemeContextProps {
   theme: ThemeType;
   setTheme: (theme: ThemeType) => void;
+  resetTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextProps>({
   theme: "system",
   setTheme: () => {},
+  resetTheme: () => {},
 });
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
@@ -42,8 +44,13 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
     AsyncStorage.setItem(THEME_KEY, newTheme);
   };
 
+  const resetTheme = () => {
+    setThemeState("system");
+    AsyncStorage.setItem(THEME_KEY, "system");
+  };
+
   return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, resetTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,14 +1,15 @@
-import { View, useColorScheme } from "react-native";
+import { View } from "react-native";
 
+import { useIsDark } from "../lib/useColorScheme";
 import { palette } from "../theme";
 
 export default function Divider() {
-  const scheme = useColorScheme();
+  const isDark = useIsDark();
 
   return (
     <View
       style={{
-        backgroundColor: scheme == "dark" ? palette.slate : palette.smoke,
+        backgroundColor: isDark ? palette.slate : palette.smoke,
         height: 1,
         width: "100%",
         marginBottom: 30,

--- a/src/components/organizations/EmptyState.tsx
+++ b/src/components/organizations/EmptyState.tsx
@@ -1,0 +1,75 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@react-navigation/native";
+import Icon from "@thedev132/hackclub-icons-rn";
+import { View, Text } from "react-native";
+
+import { palette } from "../../theme";
+
+interface EmptyStateProps {
+  isOnline: boolean;
+}
+
+export const EmptyState = ({ isOnline }: EmptyStateProps) => {
+  const { colors: themeColors } = useTheme();
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 20,
+      }}
+    >
+      {!isOnline ? (
+        <>
+          <Ionicons
+            name="cloud-offline"
+            size={48}
+            color={palette.muted}
+            style={{ marginBottom: 16 }}
+          />
+          <Text
+            style={{
+              color: themeColors.text,
+              fontSize: 18,
+              fontWeight: "600",
+              marginBottom: 8,
+            }}
+          >
+            You're Offline
+          </Text>
+          <Text
+            style={{ color: palette.muted, textAlign: "center", fontSize: 14 }}
+          >
+            Please check your internet connection and try again
+          </Text>
+        </>
+      ) : (
+        <>
+          <Icon
+            glyph="sad"
+            color={palette.muted}
+            size={48}
+            style={{ marginBottom: 16 }}
+          />
+          <Text
+            style={{
+              color: themeColors.text,
+              fontSize: 18,
+              fontWeight: "600",
+              marginBottom: 8,
+            }}
+          >
+            No Transactions Yet
+          </Text>
+          <Text
+            style={{ color: palette.muted, textAlign: "center", fontSize: 14 }}
+          >
+            Your transaction history will appear here
+          </Text>
+        </>
+      )}
+    </View>
+  );
+};

--- a/src/components/organizations/LoadingSkeleton.tsx
+++ b/src/components/organizations/LoadingSkeleton.tsx
@@ -1,0 +1,73 @@
+import { useTheme } from "@react-navigation/native";
+import { View } from "react-native";
+
+export const LoadingSkeleton = () => {
+  const { colors: themeColors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, backgroundColor: themeColors.background }}>
+      {[1, 2, 3, 4, 5].map((section) => (
+        <View key={section} style={{ marginBottom: 24 }}>
+          <View
+            style={{
+              height: 14,
+              backgroundColor: themeColors.border,
+              borderRadius: 4,
+              width: "25%",
+              marginBottom: 12,
+              marginLeft: 10,
+            }}
+          />
+
+          {[1, 2].map((item) => (
+            <View
+              key={item}
+              style={{
+                marginBottom: 1,
+                backgroundColor: themeColors.card,
+                padding: 10,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 10,
+                borderRadius: item === 1 ? 8 : 0,
+                borderBottomLeftRadius: item === 2 ? 8 : 0,
+                borderBottomRightRadius: item === 2 ? 8 : 0,
+                borderTopLeftRadius: item === 1 ? 8 : 0,
+                borderTopRightRadius: item === 1 ? 8 : 0,
+              }}
+            >
+              <View
+                style={{
+                  width: 20,
+                  height: 20,
+                  backgroundColor: themeColors.border,
+                  borderRadius: 10,
+                }}
+              />
+
+              <View style={{ flex: 1 }}>
+                <View
+                  style={{
+                    height: 14,
+                    backgroundColor: themeColors.border,
+                    borderRadius: 4,
+                    width: "80%",
+                  }}
+                />
+              </View>
+
+              <View
+                style={{
+                  height: 14,
+                  backgroundColor: themeColors.border,
+                  borderRadius: 4,
+                  width: "15%",
+                }}
+              />
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+};

--- a/src/components/organizations/TapToPayBanner.tsx
+++ b/src/components/organizations/TapToPayBanner.tsx
@@ -2,7 +2,6 @@ import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
-  useColorScheme,
   View,
   Text,
   TouchableOpacity,
@@ -10,6 +9,7 @@ import {
 } from "react-native";
 
 import { StackParamList } from "../../lib/NavigatorParamList";
+import { useIsDark } from "../../lib/useColorScheme";
 import { palette } from "../../theme";
 
 type NavigationProp = NativeStackNavigationProp<StackParamList>;
@@ -21,8 +21,7 @@ export default function TapToPayBanner({
   onDismiss: () => void;
   orgId: `org_${string}`;
 }) {
-  const scheme = useColorScheme();
-  const isDark = scheme === "dark";
+  const isDark = useIsDark();
   const navigation = useNavigation<NavigationProp>();
 
   const handlePress = () => {

--- a/src/components/organizations/TapToPayBanner.tsx
+++ b/src/components/organizations/TapToPayBanner.tsx
@@ -1,12 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Pressable,
-} from "react-native";
+import { View, Text, TouchableOpacity, Pressable } from "react-native";
 
 import { StackParamList } from "../../lib/NavigatorParamList";
 import { useIsDark } from "../../lib/useColorScheme";

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -17,6 +17,7 @@ export default function useClient() {
       headers: {
         "User-Agent": "HCB-Mobile",
       },
+      timeout: 30000,
       hooks: {
         beforeRequest: [
           async (request) => {

--- a/src/lib/useColorScheme.ts
+++ b/src/lib/useColorScheme.ts
@@ -1,0 +1,15 @@
+import { useColorScheme as useSystemColorScheme } from "react-native";
+
+import { useThemeContext } from "../ThemeContext";
+
+export function useColorScheme() {
+  const { theme } = useThemeContext();
+  const systemColorScheme = useSystemColorScheme();
+
+  return theme === "system" ? systemColorScheme : theme;
+}
+
+export function useIsDark() {
+  const colorScheme = useColorScheme();
+  return colorScheme === "dark";
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,6 +27,7 @@ import { PaginatedResponse } from "../lib/types/HcbApiObject";
 import Invitation from "../lib/types/Invitation";
 import Organization, { OrganizationExpanded } from "../lib/types/Organization";
 import ITransaction from "../lib/types/Transaction";
+import { useIsDark } from "../lib/useColorScheme";
 import { palette } from "../theme";
 import { orgColor, renderMoney } from "../util";
 
@@ -83,9 +84,9 @@ function Event({
   >(showTransactions ? `organizations/${event.id}/transactions?limit=5` : null);
 
   const { colors: themeColors } = useTheme();
-  const scheme = useColorScheme();
 
   const color = orgColor(event.id);
+  const isDark = useIsDark();
 
   return (
     <TouchableHighlight
@@ -168,7 +169,7 @@ function Event({
             {data?.playground_mode && (
               <View
                 style={{
-                  backgroundColor: scheme == "dark" ? "#283140" : "#348EDA",
+                  backgroundColor: isDark ? "#283140" : "#348EDA",
                   paddingVertical: 4,
                   paddingHorizontal: 12,
                   borderRadius: 20,
@@ -178,7 +179,7 @@ function Event({
               >
                 <Text
                   style={{
-                    color: scheme == "dark" ? "#248EDA" : "white",
+                    color: isDark ? "#248EDA" : "white",
                     fontSize: 12,
                     fontWeight: "bold",
                   }}

--- a/src/pages/organization/Donation.tsx
+++ b/src/pages/organization/Donation.tsx
@@ -26,9 +26,9 @@ import useSWR, { useSWRConfig } from "swr";
 import Button from "../../components/Button";
 import { StackParamList } from "../../lib/NavigatorParamList";
 import Organization from "../../lib/types/Organization";
+import { useIsDark } from "../../lib/useColorScheme";
 import { useLocation } from "../../lib/useLocation";
 import { palette } from "../../theme";
-import { useIsDark } from "../../lib/useColorScheme";
 
 // interface PaymentIntent {
 //   id: string;

--- a/src/pages/organization/Donation.tsx
+++ b/src/pages/organization/Donation.tsx
@@ -18,7 +18,6 @@ import {
   View,
   Alert,
   TextInput,
-  useColorScheme,
   Platform,
 } from "react-native";
 import * as Progress from "react-native-progress";
@@ -29,6 +28,7 @@ import { StackParamList } from "../../lib/NavigatorParamList";
 import Organization from "../../lib/types/Organization";
 import { useLocation } from "../../lib/useLocation";
 import { palette } from "../../theme";
+import { useIsDark } from "../../lib/useColorScheme";
 
 // interface PaymentIntent {
 //   id: string;
@@ -48,7 +48,7 @@ export default function OrganizationDonationPage({
   navigation,
 }: Props) {
   const { fetcher } = useSWRConfig();
-  const scheme = useColorScheme();
+  const isDark = useIsDark();
   const { data: organization } = useSWR<Organization>(`organizations/${orgId}`);
 
   const fetchTokenProvider = async () => {
@@ -64,7 +64,7 @@ export default function OrganizationDonationPage({
       if (didOnboarding !== "true") {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         ExpoTtpEdu.showTapToPayEducation({
-          uiMode: scheme === "dark" ? "dark" : "light",
+          uiMode: isDark ? "dark" : "light",
         });
         await AsyncStorage.setItem("ttpDidOnboarding", "true");
       }
@@ -73,7 +73,7 @@ export default function OrganizationDonationPage({
     if (Platform.OS === "ios") {
       getDidOnboarding();
     }
-  }, [scheme]);
+  }, [isDark]);
 
   return (
     <StripeTerminalProvider

--- a/src/pages/organization/index.tsx
+++ b/src/pages/organization/index.tsx
@@ -3,7 +3,6 @@ import { MenuAction, MenuView } from "@react-native-menu/menu";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import Icon from "@thedev132/hackclub-icons-rn";
 import * as Device from "expo-device";
 import groupBy from "lodash/groupBy";
 import { useEffect, useMemo, useState } from "react";
@@ -19,11 +18,12 @@ import {
 import { ALERT_TYPE, Dialog } from "react-native-alert-notification";
 import useSWR, { mutate } from "swr";
 
-// import OrganizationTitle from "../../components/organizations/OrganizationTitle";
 import Button from "../../components/Button";
 import MockTransaction, {
   MockTransactionType,
 } from "../../components/MockTransaction";
+import { EmptyState } from "../../components/organizations/EmptyState";
+import { LoadingSkeleton } from "../../components/organizations/LoadingSkeleton";
 import PlaygroundBanner from "../../components/organizations/PlaygroundBanner";
 import Transaction from "../../components/Transaction";
 import { StackParamList } from "../../lib/NavigatorParamList";
@@ -259,29 +259,22 @@ export default function OrganizationPage({
   };
 
   if (organizationLoading || userLoading) {
-    return <ActivityIndicator />;
+    return <LoadingSkeleton />;
   }
 
   return (
-    <View
-      style={{
-        flex: 1,
-        flexDirection: "column",
-        alignItems: "stretch",
-        justifyContent: "center",
-      }}
-    >
+    <View style={{ flex: 1, backgroundColor: themeColors.background }}>
       {organization !== undefined ? (
         <SectionList
-          initialNumToRender={30}
+          initialNumToRender={20}
           ListFooterComponent={() =>
-            isLoadingMore &&
-            !isLoading &&
-            !organization.playground_mode && (
-              <ActivityIndicator style={{ marginTop: 20 }} />
-            )
+            isLoadingMore && !isLoading && !organization.playground_mode ? (
+              <View style={{ padding: 20, alignItems: "center" }}>
+                <ActivityIndicator size="small" color={themeColors.primary} />
+              </View>
+            ) : null
           }
-          onEndReachedThreshold={0.5}
+          onEndReachedThreshold={0.2}
           onEndReached={() => loadMore()}
           refreshing={refreshing}
           onRefresh={() => onRefresh()}
@@ -328,55 +321,9 @@ export default function OrganizationPage({
                 )}
               </View>
 
-              {isLoading && <ActivityIndicator />}
+              {isLoading && <LoadingSkeleton />}
               {!isLoading && sections.length === 0 && !showMockData && (
-                <View
-                  style={{
-                    flex: 1,
-                    flexDirection: "row",
-                    justifyContent: "center",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  {!isOnline ? (
-                    <>
-                      <Ionicons
-                        name="cloud-offline"
-                        size={24}
-                        color={palette.muted}
-                        style={{ alignSelf: "center" }}
-                      />
-                      <Text
-                        style={{
-                          textAlign: "center",
-                          color: palette.muted,
-                          fontSize: 16,
-                        }}
-                      >
-                        Offline
-                      </Text>
-                    </>
-                  ) : (
-                    <>
-                      <Icon
-                        glyph="sad"
-                        color={palette.muted}
-                        size={24}
-                        style={{ alignSelf: "center" }}
-                      />
-                      <Text
-                        style={{
-                          textAlign: "center",
-                          color: palette.muted,
-                          fontSize: 16,
-                        }}
-                      >
-                        No Transactions
-                      </Text>
-                    </>
-                  )}
-                </View>
+                <EmptyState isOnline={isOnline} />
               )}
             </View>
           )}
@@ -444,7 +391,7 @@ export default function OrganizationPage({
           }
         />
       ) : (
-        <ActivityIndicator />
+        <LoadingSkeleton />
       )}
     </View>
   );

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -11,7 +11,6 @@ import {
   View,
   Pressable,
   ScrollView,
-  useColorScheme,
   Animated,
 } from "react-native";
 import useSWR from "swr";
@@ -20,6 +19,7 @@ import AuthContext from "../../auth";
 import Button from "../../components/Button";
 import { SettingsStackParamList } from "../../lib/NavigatorParamList";
 import User from "../../lib/types/User";
+import { useIsDark } from "../../lib/useColorScheme";
 import { palette } from "../../theme";
 import { useThemeContext } from "../../ThemeContext";
 
@@ -59,7 +59,6 @@ export default function SettingsPage({ navigation }: Props) {
   const { data: user } = useSWR<User>("user");
   const { colors } = useTheme();
   const { theme, setTheme } = useThemeContext();
-  const systemColorScheme = useColorScheme();
   const animation = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -87,8 +86,7 @@ export default function SettingsPage({ navigation }: Props) {
     setTheme(value);
   };
 
-  const isDark =
-    theme === "dark" || (theme === "system" && systemColorScheme === "dark");
+  const isDark = useIsDark();
   const dividerColor = isDark ? palette.slate : colors.border;
   const showTutorials = isTapToPaySupported();
 

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -91,7 +91,12 @@ export default function SettingsPage({ navigation }: Props) {
 
   const handleSignOut = async () => {
     resetTheme();
-    await AsyncStorage.multiRemove([THEME_KEY, "pinnedOrgs", "frozenCardsShown", "ttpDidOnboarding"]);
+    await AsyncStorage.multiRemove([
+      THEME_KEY,
+      "pinnedOrgs",
+      "frozenCardsShown",
+      "ttpDidOnboarding",
+    ]);
     cache.clear();
     setTokens(null);
   };

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -16,6 +16,7 @@ import {
 import useSWR from "swr";
 
 import AuthContext from "../../auth";
+import { useCache } from "../../cacheProvider";
 import Button from "../../components/Button";
 import { SettingsStackParamList } from "../../lib/NavigatorParamList";
 import User from "../../lib/types/User";
@@ -58,12 +59,14 @@ export default function SettingsPage({ navigation }: Props) {
   const { setTokens } = useContext(AuthContext);
   const { data: user } = useSWR<User>("user");
   const { colors } = useTheme();
-  const { theme, setTheme } = useThemeContext();
+  const cache = useCache();
+  const { theme, setTheme, resetTheme } = useThemeContext();
   const animation = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     (async () => {
       const storedTheme = await AsyncStorage.getItem(THEME_KEY);
+      console.log(storedTheme);
       if (
         storedTheme === "light" ||
         storedTheme === "dark" ||
@@ -84,6 +87,13 @@ export default function SettingsPage({ navigation }: Props) {
 
   const handleThemeChange = async (value: "light" | "dark" | "system") => {
     setTheme(value);
+  };
+
+  const handleSignOut = async () => {
+    resetTheme();
+    await AsyncStorage.clear();
+    cache.clear();
+    setTokens(null);
   };
 
   const isDark = useIsDark();
@@ -384,7 +394,7 @@ export default function SettingsPage({ navigation }: Props) {
             paddingVertical: 16,
             alignItems: "center",
           }}
-          onPress={() => setTokens(null)}
+          onPress={() => handleSignOut()}
         >
           Sign Out
         </Button>

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -91,7 +91,7 @@ export default function SettingsPage({ navigation }: Props) {
 
   const handleSignOut = async () => {
     resetTheme();
-    await AsyncStorage.clear();
+    await AsyncStorage.multiRemove([THEME_KEY, "pinnedOrgs", "frozenCardsShown", "ttpDidOnboarding"]);
     cache.clear();
     setTokens(null);
   };


### PR DESCRIPTION
Create new util called useIsDark() which effectively checks the themeContext and color scheme to identify the correct theme color as the new theme context now accepts a "system" option. The organization page has much better loading indicator/skeleton and invalidated storage and cache on signout. 
![image](https://github.com/user-attachments/assets/d2149ab1-8d79-49d9-836a-8114ec8d8075)
