### PR TITLE
Match Transaction coloring to HCB

### DIFF
--- a/src/components/MockTransaction.tsx
+++ b/src/components/MockTransaction.tsx
@@ -76,6 +76,7 @@ function MockTransactionComponent({
   hideMissingReceipt?: boolean;
 }) {
   const { colors: themeColors } = useTheme();
+  const isLight = themeColors.background === '#fff' || themeColors.background === '#ffffff';
   const hasMissingReceipt =
     transaction?.localHcbCode?.receipts.length === 0 &&
     transaction.amount.cents < 0 &&
@@ -89,7 +90,12 @@ function MockTransactionComponent({
           flexDirection: "row",
           alignItems: "center",
           gap: 10,
-          backgroundColor: themeColors.card,
+          backgroundColor:
+            transaction.feePayment || transaction.amount.cents < 0
+              ? (isLight ? '#F9E3E7' : '#351921')
+              : transaction.amount.cents > 0
+                ? (isLight ? '#E4F6F1' : '#234740')
+                : themeColors.card,
           borderTopLeftRadius: top ? 8 : 0,
           borderTopRightRadius: top ? 8 : 0,
           borderBottomLeftRadius: bottom ? 8 : 0,
@@ -112,19 +118,35 @@ function MockTransactionComponent({
         {transaction?.localHcbCode?.memo?.replaceAll(/\s{2,}/g, " ") || ""}
       </Text>
       {hasMissingReceipt && !hideMissingReceipt && (
-        <View>
-          <Ionicons name="receipt-outline" color={palette.muted} size={18} />
-          <Ionicons
-            name="alert"
-            color={palette.warning}
-            style={{ position: "absolute", top: -8, left: -10 }}
-            size={18}
-          />
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            borderWidth: 1,
+            borderColor: "#ff8c37",
+            borderRadius: 20,
+            paddingHorizontal: 5,
+            paddingVertical: 2,
+            marginRight: 4,
+            backgroundColor: "transparent",
+          }}
+        >
+          <Icon glyph="payment-docs" color="#ff8c37" size={18} />
+          <Text
+            style={{
+              color: "#ff8c37",
+              fontSize: 12,
+              fontFamily: "monospace",
+              fontWeight: "bold",
+            }}
+          >
+            0
+          </Text>
         </View>
       )}
       <Text
         style={{
-          color: transaction?.amount.cents > 0 ? "#33d6a6" : "#d63333",
+          color: themeColors.text,
         }}
       >
         {renderMoney(transaction?.amount.cents)}

--- a/src/components/MockTransaction.tsx
+++ b/src/components/MockTransaction.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "@react-navigation/native";
 import Icon from "@thedev132/hackclub-icons-rn";
 import { memo } from "react";
 import { View, Text, ViewProps, StyleSheet } from "react-native";
+import { useIsDark } from "../lib/useColorScheme";
 
 import { palette } from "../theme";
 import { renderMoney } from "../util";
@@ -76,7 +77,7 @@ function MockTransactionComponent({
   hideMissingReceipt?: boolean;
 }) {
   const { colors: themeColors } = useTheme();
-  const isLight = themeColors.background === '#fff' || themeColors.background === '#ffffff';
+  const isDark = useIsDark();
   const hasMissingReceipt =
     transaction?.localHcbCode?.receipts.length === 0 &&
     transaction.amount.cents < 0 &&
@@ -92,9 +93,9 @@ function MockTransactionComponent({
           gap: 10,
           backgroundColor:
             transaction.feePayment || transaction.amount.cents < 0
-              ? (isLight ? '#F9E3E7' : '#351921')
+              ? (isDark ? '#351921' : '#F9E3E7')
               : transaction.amount.cents > 0
-                ? (isLight ? '#E4F6F1' : '#234740')
+                ? (isDark ? '#234740' : '#d7f7ee')
                 : themeColors.card,
           borderTopLeftRadius: top ? 8 : 0,
           borderTopRightRadius: top ? 8 : 0,

--- a/src/components/MockTransaction.tsx
+++ b/src/components/MockTransaction.tsx
@@ -1,12 +1,11 @@
-import { Ionicons } from "@expo/vector-icons";
 import { faPaypal } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { useTheme } from "@react-navigation/native";
 import Icon from "@thedev132/hackclub-icons-rn";
 import { memo } from "react";
 import { View, Text, ViewProps, StyleSheet } from "react-native";
-import { useIsDark } from "../lib/useColorScheme";
 
+import { useIsDark } from "../lib/useColorScheme";
 import { palette } from "../theme";
 import { renderMoney } from "../util";
 
@@ -93,9 +92,13 @@ function MockTransactionComponent({
           gap: 10,
           backgroundColor:
             transaction.feePayment || transaction.amount.cents < 0
-              ? (isDark ? '#351921' : '#F9E3E7')
+              ? isDark
+                ? "#351921"
+                : "#F9E3E7"
               : transaction.amount.cents > 0
-                ? (isDark ? '#234740' : '#d7f7ee')
+                ? isDark
+                  ? "#234740"
+                  : "#d7f7ee"
                 : themeColors.card,
           borderTopLeftRadius: top ? 8 : 0,
           borderTopRightRadius: top ? 8 : 0,
@@ -129,7 +132,7 @@ function MockTransactionComponent({
             paddingHorizontal: 5,
             paddingVertical: 2,
             marginRight: 4,
-            backgroundColor: "transparent",
+            backgroundColor: isDark ? "#2E161D" : "#FBEAED",
           }}
         >
           <Icon glyph="payment-docs" color="#ff8c37" size={18} />

--- a/src/components/Transaction.tsx
+++ b/src/components/Transaction.tsx
@@ -17,6 +17,7 @@ import { palette, theme } from "../theme";
 import { renderMoney } from "../util";
 
 import UserAvatar from "./UserAvatar";
+import { useIsDark } from "../lib/useColorScheme";
 
 function transactionIcon({ code, ...transaction }: TransactionWithoutId) {
   switch (code) {
@@ -125,7 +126,7 @@ function Transaction({
   hideMissingReceipt?: boolean;
 }) {
   const { colors: themeColors } = useTheme();
-  const isLight = themeColors.background !== '#fff';
+  const isDark = useIsDark();
   
   return (
     <View>
@@ -138,9 +139,9 @@ function Transaction({
             gap: 10,
             backgroundColor:
               transaction.declined || transaction.amount_cents < 0
-                ? (isLight ? '#F9E3E7' : '#351921')
+                ? (isDark ? '#351921' : '#F9E3E7')
                 : transaction.amount_cents > 0
-                  ? (isLight ? '#d7f7ee' : '#234740')
+                  ? (isDark ? '#234740' : '#d7f7ee')
                   : themeColors.card,
             borderTopLeftRadius: top ? 8 : 0,
             borderTopRightRadius: top ? 8 : 0,
@@ -170,9 +171,9 @@ function Transaction({
             style={
               transaction.declined
                 ? {
-                    backgroundColor: isLight ? '#891A2A' : '#401A23',
+                    backgroundColor: isDark ? '#401A23' : '#891A2A',
                     borderWidth: 1,
-                    borderColor: isLight ? '#891A2A' : '#401A23',
+                    borderColor: isDark ? '#401A23' : '#891A2A',
                     borderRadius: 10,
                     paddingHorizontal: 8,
                     paddingVertical: 2,
@@ -192,7 +193,7 @@ function Transaction({
             <Text
               style={
                 transaction.declined
-                  ? { color: isLight ? "#fff" : '#891A2A', fontSize: 12, fontWeight: 'bold' }
+                  ? { color: isDark ? "#891A2A" : '#fff', fontSize: 12, fontWeight: 'bold' }
                   : { color: '#8492a6', fontSize: 12, fontWeight: 'bold' }
               }
             >

--- a/src/components/Transaction.tsx
+++ b/src/components/Transaction.tsx
@@ -1,4 +1,3 @@
-import { Ionicons } from "@expo/vector-icons";
 import { faPaypal } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { useTheme } from "@react-navigation/native";
@@ -13,11 +12,11 @@ import {
   TransactionType,
   TransactionWithoutId,
 } from "../lib/types/Transaction";
-import { palette, theme } from "../theme";
+import { useIsDark } from "../lib/useColorScheme";
+import { palette } from "../theme";
 import { renderMoney } from "../util";
 
 import UserAvatar from "./UserAvatar";
-import { useIsDark } from "../lib/useColorScheme";
 
 function transactionIcon({ code, ...transaction }: TransactionWithoutId) {
   switch (code) {
@@ -127,7 +126,7 @@ function Transaction({
 }) {
   const { colors: themeColors } = useTheme();
   const isDark = useIsDark();
-  
+
   return (
     <View>
       <View
@@ -139,9 +138,13 @@ function Transaction({
             gap: 10,
             backgroundColor:
               transaction.declined || transaction.amount_cents < 0
-                ? (isDark ? '#351921' : '#F9E3E7')
+                ? isDark
+                  ? "#351921"
+                  : "#F9E3E7"
                 : transaction.amount_cents > 0
-                  ? (isDark ? '#234740' : '#d7f7ee')
+                  ? isDark
+                    ? "#234740"
+                    : "#d7f7ee"
                   : themeColors.card,
             borderTopLeftRadius: top ? 8 : 0,
             borderTopRightRadius: top ? 8 : 0,
@@ -155,7 +158,13 @@ function Transaction({
         {transaction.appearance == "hackathon_grant" && (
           <LinearGradient
             colors={["#e2b142", "#fbe87a", "#e2b142", "#fbe87a"]}
-            style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+            }}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 0 }}
           />
@@ -171,9 +180,9 @@ function Transaction({
             style={
               transaction.declined
                 ? {
-                    backgroundColor: isDark ? '#401A23' : '#891A2A',
+                    backgroundColor: isDark ? "#401A23" : "#891A2A",
                     borderWidth: 1,
-                    borderColor: isDark ? '#401A23' : '#891A2A',
+                    borderColor: isDark ? "#401A23" : "#891A2A",
                     borderRadius: 10,
                     paddingHorizontal: 8,
                     paddingVertical: 2,
@@ -181,8 +190,8 @@ function Transaction({
                   }
                 : {
                     borderWidth: 1,
-                    borderStyle: 'dashed',
-                    borderColor: '#8492a6',
+                    borderStyle: "dashed",
+                    borderColor: "#8492a6",
                     borderRadius: 10,
                     paddingHorizontal: 8,
                     paddingVertical: 2,
@@ -193,11 +202,15 @@ function Transaction({
             <Text
               style={
                 transaction.declined
-                  ? { color: isDark ? "#891A2A" : '#fff', fontSize: 12, fontWeight: 'bold' }
-                  : { color: '#8492a6', fontSize: 12, fontWeight: 'bold' }
+                  ? {
+                      color: isDark ? "#891A2A" : "#fff",
+                      fontSize: 12,
+                      fontWeight: "bold",
+                    }
+                  : { color: "#8492a6", fontSize: 12, fontWeight: "bold" }
               }
             >
-              {transaction.declined ? 'Declined' : 'Pending'}
+              {transaction.declined ? "Declined" : "Pending"}
             </Text>
           </View>
         )}
@@ -206,11 +219,11 @@ function Transaction({
           style={{
             fontSize: 14,
             color:
-transaction.appearance == "hackathon_grant"
-                  ? palette.black
-                  : transaction.pending
-                    ? palette.muted
-                    : themeColors.text,
+              transaction.appearance == "hackathon_grant"
+                ? palette.black
+                : transaction.pending
+                  ? palette.muted
+                  : themeColors.text,
             overflow: "hidden",
             flex: 1,
           }}
@@ -241,7 +254,7 @@ transaction.appearance == "hackathon_grant"
               paddingHorizontal: 5,
               paddingVertical: 2,
               marginRight: 4,
-              backgroundColor: "transparent",
+              backgroundColor: isDark ? "#2E161D" : "#FBEAED",
             }}
           >
             <Icon glyph="payment-docs" color="#ff8c37" size={18} />
@@ -260,8 +273,9 @@ transaction.appearance == "hackathon_grant"
         <Text
           style={{
             color:
-                transaction.appearance == "hackathon_grant"
-                  ? palette.black : themeColors.text,
+              transaction.appearance == "hackathon_grant"
+                ? palette.black
+                : themeColors.text,
           }}
         >
           {renderMoney(transaction.amount_cents)}

--- a/src/components/Transaction.tsx
+++ b/src/components/Transaction.tsx
@@ -13,7 +13,7 @@ import {
   TransactionType,
   TransactionWithoutId,
 } from "../lib/types/Transaction";
-import { palette } from "../theme";
+import { palette, theme } from "../theme";
 import { renderMoney } from "../util";
 
 import UserAvatar from "./UserAvatar";
@@ -125,100 +125,147 @@ function Transaction({
   hideMissingReceipt?: boolean;
 }) {
   const { colors: themeColors } = useTheme();
-
+  const isLight = themeColors.background !== '#fff';
+  
   return (
-    <View
-      style={StyleSheet.compose(
-        {
-          padding: 10,
-          flexDirection: "row",
-          alignItems: "center",
-          gap: 10,
-          backgroundColor:
-            transaction.appearance == "hackathon_grant"
-              ? undefined
-              : themeColors.card,
-          borderTopLeftRadius: top ? 8 : 0,
-          borderTopRightRadius: top ? 8 : 0,
-          borderBottomLeftRadius: bottom ? 8 : 0,
-          borderBottomRightRadius: bottom ? 8 : 0,
-          overflow: "hidden",
-        },
-        style,
-      )}
-    >
-      {transaction.appearance == "hackathon_grant" && (
-        <LinearGradient
-          colors={["#e2b142", "#fbe87a", "#e2b142", "#fbe87a"]}
-          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 0 }}
-        />
-      )}
-
-      <TransactionIcon
-        transaction={transaction}
-        hideAvatar={hideAvatar}
-        hideIcon={hideIcon}
-      />
-      <Text
-        numberOfLines={1}
-        style={{
-          fontSize: 14,
-          color:
-            transaction.appearance == "hackathon_grant"
-              ? palette.black
-              : transaction.pending || transaction.declined
-                ? palette.muted
-                : themeColors.text,
-          overflow: "hidden",
-          flex: 1,
-        }}
+    <View>
+      <View
+        style={StyleSheet.compose(
+          {
+            padding: 10,
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            backgroundColor:
+              transaction.declined || transaction.amount_cents < 0
+                ? (isLight ? '#F9E3E7' : '#351921')
+                : transaction.amount_cents > 0
+                  ? (isLight ? '#d7f7ee' : '#234740')
+                  : themeColors.card,
+            borderTopLeftRadius: top ? 8 : 0,
+            borderTopRightRadius: top ? 8 : 0,
+            borderBottomLeftRadius: bottom ? 8 : 0,
+            borderBottomRightRadius: bottom ? 8 : 0,
+            overflow: "hidden",
+          },
+          style,
+        )}
       >
-        {!hidePendingLabel &&
-          (transaction.declined
-            ? "Declined: "
-            : transaction.pending
-              ? "Pending: "
-              : "")}
-        {match(transaction)
-          .with(
-            { appearance: "hackathon_grant", has_custom_memo: false },
-            () => "💰 Hackathon grant",
-          )
-          // .with(
-          //   {
-          //     card_charge: { merchant: { smart_name: P.string } },
-          //     has_custom_memo: false,
-          //   },
-          //   (tx) => tx.card_charge.merchant.smart_name,
-          // )
-          .otherwise((tx) => tx.memo)
-          .replaceAll(/\s{2,}/g, " ")}
-      </Text>
-      {transaction.missing_receipt && !hideMissingReceipt && (
-        <View>
-          <Ionicons name="receipt-outline" color={palette.muted} size={18} />
-          <Ionicons
-            name="alert"
-            color={palette.warning}
-            style={{ position: "absolute", top: -8, left: -10 }}
-            size={18}
+        {transaction.appearance == "hackathon_grant" && (
+          <LinearGradient
+            colors={["#e2b142", "#fbe87a", "#e2b142", "#fbe87a"]}
+            style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
           />
-        </View>
-      )}
-      <Text
-        style={{
-          color:
-            transaction.appearance == "hackathon_grant"
-              ? palette.black
-              : transaction.amount_cents > 0
-                ? "#33d6a6"
-                : "#d63333",
-        }}
-      >
-        {renderMoney(transaction.amount_cents)}
-      </Text>
+        )}
+
+        <TransactionIcon
+          transaction={transaction}
+          hideAvatar={hideAvatar}
+          hideIcon={hideIcon}
+        />
+        {!hidePendingLabel && (transaction.declined || transaction.pending) && (
+          <View
+            style={
+              transaction.declined
+                ? {
+                    backgroundColor: isLight ? '#891A2A' : '#401A23',
+                    borderWidth: 1,
+                    borderColor: isLight ? '#891A2A' : '#401A23',
+                    borderRadius: 10,
+                    paddingHorizontal: 8,
+                    paddingVertical: 2,
+                    marginRight: 4,
+                  }
+                : {
+                    borderWidth: 1,
+                    borderStyle: 'dashed',
+                    borderColor: '#8492a6',
+                    borderRadius: 10,
+                    paddingHorizontal: 8,
+                    paddingVertical: 2,
+                    marginRight: 4,
+                  }
+            }
+          >
+            <Text
+              style={
+                transaction.declined
+                  ? { color: isLight ? "#fff" : '#891A2A', fontSize: 12, fontWeight: 'bold' }
+                  : { color: '#8492a6', fontSize: 12, fontWeight: 'bold' }
+              }
+            >
+              {transaction.declined ? 'Declined' : 'Pending'}
+            </Text>
+          </View>
+        )}
+        <Text
+          numberOfLines={1}
+          style={{
+            fontSize: 14,
+            color:
+transaction.appearance == "hackathon_grant"
+                  ? palette.black
+                  : transaction.pending
+                    ? palette.muted
+                    : themeColors.text,
+            overflow: "hidden",
+            flex: 1,
+          }}
+        >
+          {match(transaction)
+            .with(
+              { appearance: "hackathon_grant", has_custom_memo: false },
+              () => "💰 Hackathon grant",
+            )
+            // .with(
+            //   {
+            //     card_charge: { merchant: { smart_name: P.string } },
+            //     has_custom_memo: false,
+            //   },
+            //   (tx) => tx.card_charge.merchant.smart_name,
+            // )
+            .otherwise((tx) => tx.memo)
+            .replaceAll(/\s{2,}/g, " ")}
+        </Text>
+        {transaction.missing_receipt && !hideMissingReceipt && (
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              borderWidth: 1,
+              borderColor: "#ff8c37",
+              borderRadius: 20,
+              paddingHorizontal: 5,
+              paddingVertical: 2,
+              marginRight: 4,
+              backgroundColor: "transparent",
+            }}
+          >
+            <Icon glyph="payment-docs" color="#ff8c37" size={18} />
+            <Text
+              style={{
+                color: "#ff8c37",
+                fontSize: 12,
+                fontFamily: "monospace",
+                fontWeight: "bold",
+              }}
+            >
+              0
+            </Text>
+          </View>
+        )}
+        <Text
+          style={{
+            color:
+                transaction.appearance == "hackathon_grant"
+                  ? palette.black : themeColors.text,
+          }}
+        >
+          {renderMoney(transaction.amount_cents)}
+        </Text>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
Fixed missing receipt icon, denied chip, pending chip, and made background of transactions the same as on HCB:

![simulator_screenshot_B34AAFBA-24EB-4B1F-AFD7-EB540C300177](https://github.com/user-attachments/assets/92fa630a-37b4-4849-9d72-338373549244)
![simulator_screenshot_C959CFE8-50A3-485A-B37A-0F4F177A86D4](https://github.com/user-attachments/assets/9a531534-f22e-4a19-b6ec-4534ae96b265)
