### PR TITLE
Use Hack club Icons instead of Ionicons

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from "@expo/vector-icons";
+import Icon from "@thedev132/hackclub-icons-rn";
 import { PropsWithChildren } from "react";
 import {
   ActivityIndicator,
@@ -30,14 +30,15 @@ export interface ButtonProps {
     | "900";
   loading?: boolean;
   disabled?: boolean;
-  icon?: React.ComponentProps<typeof Ionicons>["name"];
+  icon?: React.ComponentProps<typeof Icon>["glyph"];
+  iconSize?: number;
+  iconOffset?: number;
 }
 
 const styles = StyleSheet.create({
   button: {
     backgroundColor: palette.primary,
     borderColor: "#e85d6f",
-    borderTopWidth: 1,
     color: "white",
     paddingVertical: 10,
     paddingHorizontal: 16,
@@ -75,14 +76,25 @@ export default function Button(
       disabled={props.loading || props.disabled}
     >
       {props.icon && (
-        <Ionicons
-          name={props.icon}
+        <View
           style={{
-            ...styles.buttonText,
-            color: props.iconColor || props.color || styles.buttonText.color,
-            opacity: props.loading ? 0 : 1,
+            width: 24,
+            height: 24,
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+            paddingBottom: props.iconOffset || 0,
           }}
-        />
+        >
+          <Icon
+            size={props.iconSize || 24}
+            glyph={props.icon}
+            style={{
+              color: props.iconColor || props.color || styles.buttonText.color,
+              opacity: props.loading ? 0 : 1,
+            }}
+          />
+        </View>
       )}
       <Text
         style={{

--- a/src/pages/card.tsx
+++ b/src/pages/card.tsx
@@ -686,7 +686,7 @@ export default function CardPage({
                     }}
                     color="#186177"
                     iconColor="#186177"
-                    icon="snow"
+                    icon="freeze"
                     onPress={() => toggleCardFrozen()}
                     loading={isUpdatingStatus}
                   >
@@ -703,7 +703,7 @@ export default function CardPage({
                     }}
                     color="white"
                     iconColor="white"
-                    icon={detailsRevealed ? "eye-off" : "eye"}
+                    icon={detailsRevealed ? "private-fill" : "view"}
                     onPress={toggleCardDetails}
                     loading={detailsLoading}
                   >

--- a/src/pages/organization/Settings.tsx
+++ b/src/pages/organization/Settings.tsx
@@ -60,7 +60,9 @@ export default function OrganizationSettingsPage({
       >
         <Text style={{ color: themeColors.text, fontSize: 18 }}>Members</Text>
         <Button
-          icon="add-circle-outline"
+          icon="member-add"
+          iconSize={28}
+          iconOffset={2}
           onPress={() =>
             Linking.openURL(
               `https://hcb.hackclub.com/${organization.slug}/invites/new`,


### PR DESCRIPTION
I changed the button icons to use the hack club [icons](https://icons.hackclub.com). In the future this is useful when we add more HCB buttons and need those same icons. 
![simulator_screenshot_7F68BAB9-63C9-4660-AC0E-65581746AC4B](https://github.com/user-attachments/assets/75a45456-114a-47ab-b910-14e59d48e686)
![simulator_screenshot_B0226AA7-F7A2-4DC4-8F46-36DF0146FA1B](https://github.com/user-attachments/assets/7afa659e-43ed-48b6-9192-87d67bc60a6f)
