### PR TITLE
[bug] Fix grant card number bug

### DIFF
--- a/src/pages/card.tsx
+++ b/src/pages/card.tsx
@@ -701,9 +701,7 @@ export default function CardPage({
                     >
                       {detailsRevealed && details
                         ? renderCardNumber(details.number)
-                        : redactedCardNumber(
-                            card?.last4,
-                          )}
+                        : redactedCardNumber(card?.last4)}
                     </Text>
                   )}
                 </View>

--- a/src/pages/card.tsx
+++ b/src/pages/card.tsx
@@ -702,7 +702,7 @@ export default function CardPage({
                       {detailsRevealed && details
                         ? renderCardNumber(details.number)
                         : redactedCardNumber(
-                            isGrantCard ? _card.last4 : card?.last4,
+                            card?.last4,
                           )}
                     </Text>
                   )}


### PR DESCRIPTION
The last 4 numbers would not show on grant cards from an org you're not in. 