### PR TITLE
Remove user details from feedback capture

### DIFF
--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -672,8 +672,6 @@ export default function SettingsPage({ navigation }: Props) {
           try {
             Sentry.captureFeedback(
               {
-                name: user?.name || "",
-                email: user?.email || "",
                 message: feedback.message,
               } as SendFeedbackParams,
               {


### PR DESCRIPTION
Removed user name and email from feedback submission. Since these become public we wanna keep the publisher anon