### PR TITLE
[Deep Linking] Disable for `/mobile`

### DIFF
--- a/src/core/AppContent.tsx
+++ b/src/core/AppContent.tsx
@@ -434,7 +434,8 @@ export default function AppContent({
           path.startsWith("/branding") ||
           path.startsWith("/security") ||
           path.startsWith("/roles") ||
-          path.startsWith("/wrapped")
+          path.startsWith("/wrapped") ||
+          path.startsWith("/mobile")
         ) {
           Linking.openURL(new URL(path, "https://hcb.hackclub.com").toString());
           return undefined;


### PR DESCRIPTION
An alternative solution would be to route to the homepage of the app but I'm not sure how to do that. I think that might be better.