### PR TITLE
Add Share Menu to Transaction

### DIFF
--- a/src/pages/Transaction.tsx
+++ b/src/pages/Transaction.tsx
@@ -79,7 +79,7 @@ export default function TransactionPage({
         headerRight: () => (
           <TouchableOpacity
             onPress={async () => {
-              const hcbCode = transaction.id.split("txn_")[1];
+              const hcbCode = transaction.id.slice(4);
               const url = `https://hcb.hackclub.com/hcb/${hcbCode}`;
               try {
                 await Share.share({


### PR DESCRIPTION
This allows you to share this transaction whether to HCB for support, team members, or to utilize features not present in app