### PR TITLE
Simplify logic of rendering cards in cards page

### DIFF
--- a/src/pages/cards/cards.tsx
+++ b/src/pages/cards/cards.tsx
@@ -223,10 +223,10 @@ export default function CardsPage({ navigation }: Props) {
   ]);
 
   const combineCards = useCallback(() => {
-    if (!cards || !grantCards) return;
+    if (!cards) return;
 
     const grantCardMap = new Map<string, string>();
-    grantCards.forEach((grantCard) => {
+    (grantCards || []).forEach((grantCard) => {
       if (grantCard.card_id) {
         grantCardMap.set(grantCard.card_id, grantCard.id);
       }


### PR DESCRIPTION
Cards page will render only stripe cards with optional grant id param instead of grant card vs. stripe card issues. This should fix the issue of frozen graphics not showing for some users if they have a frozen grant card