### PR TITLE
Show recent transactions on organization cards

### DIFF
--- a/src/components/organizations/Event.tsx
+++ b/src/components/organizations/Event.tsx
@@ -11,15 +11,18 @@ import {
 } from "react-native";
 import useSWR from "swr";
 
+import { PaginatedResponse } from "../../lib/types/HcbApiObject";
 import Invitation from "../../lib/types/Invitation";
 import Organization, {
   OrganizationExpanded,
 } from "../../lib/types/Organization";
+import ITransaction, { TransactionWithoutId } from "../../lib/types/Transaction";
 import { useIsDark } from "../../lib/useColorScheme";
 import { useStripeTerminalInit } from "../../lib/useStripeTerminalInit";
 import { palette } from "../../styles/theme";
 import * as Haptics from "../../utils/haptics";
 import { orgColor } from "../../utils/util";
+import Transaction from "../transaction/Transaction";
 
 import EventBalance from "./EventBalance";
 
@@ -32,7 +35,7 @@ const Event = memo(
     isActive,
     style,
     invitation,
-    // showTransactions = false,
+    showTransactions = false,
   }: ViewProps & {
     event: Organization;
     hideBalance?: boolean;
@@ -46,6 +49,13 @@ const Event = memo(
       hideBalance ? null : `organizations/${event.id}`,
       { keepPreviousData: true },
     );
+
+    const { data: transactionsData } = useSWR<PaginatedResponse<ITransaction>>(
+      showTransactions ? `organizations/${event.id}/transactions?limit=35` : null,
+      { keepPreviousData: true },
+    );
+
+    const recentTransactions = (transactionsData?.data?.slice(0, 7) ?? []) as TransactionWithoutId[];
 
     const { colors: themeColors } = useTheme();
     useStripeTerminalInit({
@@ -168,6 +178,21 @@ const Event = memo(
             />
           </View>
         </View>
+        {showTransactions && recentTransactions.length > 0 && (
+          <View style={{ paddingHorizontal: 12, paddingBottom: 12 }}>
+            {recentTransactions.map((transaction, index) => (
+              <Transaction
+                key={transaction.id ?? index}
+                transaction={transaction}
+                orgId={event.id}
+                top={index === 0}
+                bottom={index === recentTransactions.length - 1}
+                hideMissingReceipt
+                hideAvatar
+              />
+            ))}
+          </View>
+        )}
       </>
     );
 
@@ -249,6 +274,7 @@ const Event = memo(
       prevProps.event.background_image === nextProps.event.background_image &&
       prevProps.hideBalance === nextProps.hideBalance &&
       prevProps.isActive === nextProps.isActive &&
+      prevProps.showTransactions === nextProps.showTransactions &&
       prevProps.invitation?.id === nextProps.invitation?.id
     );
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,11 +44,9 @@ const EventItem = memo(
   ({
     organization,
     navigation,
-    orgCount,
   }: {
     organization: Organization;
     navigation: NativeStackNavigationProp<StackParamList, "Organizations">;
-    orgCount: number;
   }) => {
     const drag = useReorderableDrag();
     const handlePress = useCallback(() => {
@@ -63,7 +61,7 @@ const EventItem = memo(
         event={organization}
         drag={drag}
         isActive={false}
-        showTransactions={orgCount <= 2}
+        showTransactions
         onPress={handlePress}
       />
     );
@@ -72,8 +70,7 @@ const EventItem = memo(
     prev.organization.id === next.organization.id &&
     prev.organization.name === next.organization.name &&
     prev.organization.icon === next.organization.icon &&
-    prev.organization.background_image === next.organization.background_image &&
-    prev.orgCount === next.orgCount,
+    prev.organization.background_image === next.organization.background_image,
 );
 
 EventItem.displayName = "EventItem";
@@ -256,17 +253,14 @@ export default function App({ navigation }: Props) {
     }, [mutate]),
   );
 
-  const orgCount = organizations?.length ?? 0;
-
   const renderItem = useCallback(
     ({ item: organization }: { item: Organization }) => (
       <EventItem
         organization={organization}
         navigation={navigation}
-        orgCount={orgCount}
       />
     ),
-    [navigation, orgCount],
+    [navigation],
   );
 
   // Show cached data even if there's an error


### PR DESCRIPTION
## Summary of the problem

Organizations should display recent transactions on their cards to give users quick visibility into activity without navigating to a detailed view.

## Describe your changes

- Added transaction fetching to the `Event` component with a new `showTransactions` prop that controls whether to display recent transactions
- Fetches up to 35 transactions from the API and displays the 7 most recent ones
- Renders transactions using the existing `Transaction` component with appropriate styling (padding, borders)
- Simplified the `EventItem` component in the organizations page to always show transactions (removed the `orgCount` conditional logic)
- Updated memoization checks to include the new `showTransactions` prop to prevent unnecessary re-renders
- Added necessary type imports (`PaginatedResponse`, `ITransaction`, `TransactionWithoutId`)

The change removes the previous logic that only showed transactions when there were 2 or fewer organizations, and instead always displays them on the organizations page.

## Checklist

- [x] Descriptive PR title
- [x] Easily digestible commits
- [ ] CI passes _(pending)_
- [ ] Tested by submitter before requesting review _(pending)_

https://claude.ai/code/session_016J4wLvcboPjF5eaivq9KW4