### PR TITLE
Add recent transactions section to event details page

### DIFF
--- a/app/(app)/(events)/[id]/index.tsx
+++ b/app/(app)/(events)/[id]/index.tsx
@@ -18,9 +18,10 @@ import { EmptyState } from "@/components/organizations/EmptyState";
 import Header from "@/components/organizations/Header";
 import PlaygroundBanner from "@/components/organizations/PlaygroundBanner";
 import TapToPayBanner from "@/components/organizations/TapToPayBanner";
+import TransactionWrapper from "@/components/organizations/TransactionWrapper";
 import useTransactions from "@/lib/organization/useTransactions";
 import Organization, { OrganizationExpanded } from "@/lib/types/Organization";
-import { TransactionWithoutId } from "@/lib/types/Transaction";
+import ITransaction, { TransactionWithoutId } from "@/lib/types/Transaction";
 import User from "@/lib/types/User";
 import { useOffline } from "@/lib/useOffline";
 import { useOfflineSWR } from "@/lib/useOfflineSWR";
@@ -222,6 +223,8 @@ export default function Page() {
     [transactions],
   );
 
+  const recentTransactions = useMemo(() => transactions.slice(0, 7), [transactions]);
+
   const renderListHeader = useCallback(() => {
     if (!organization) return null;
 
@@ -259,22 +262,62 @@ export default function Page() {
   return (
     <ScrollView style={{ flex: 1, backgroundColor: themeColors.background }}>
       {renderListHeader()}
-      <View style={{ paddingHorizontal: 20 }}>
+      <View style={{ paddingHorizontal: 20, gap: 16 }}>
+        {recentTransactions.length > 0 && (
+          <View>
+            <View
+              style={{
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: 8,
+              }}
+            >
+              <Text style={{ fontSize: 18, fontWeight: "600" }}>
+                Recent transactions
+              </Text>
+              <Pressable
+                onPress={() =>
+                  router.push({
+                    pathname: "/(events)/[id]/transactions",
+                    params: { id: params.id, fallbackData: params.fallbackData },
+                  })
+                }
+              >
+                <Text style={{ opacity: 0.5 }}>View all</Text>
+              </Pressable>
+            </View>
+            <View
+              style={{
+                backgroundColor: themeColors.card,
+                borderRadius: 16,
+                overflow: "hidden",
+              }}
+            >
+              {recentTransactions.map((transaction, index) => (
+                <TransactionWrapper
+                  key={(transaction as ITransaction).id || index}
+                  item={transaction as ITransaction}
+                  user={user}
+                  organization={organization}
+                  orgId={params.id as `org_${string}`}
+                  isFirst={index === 0}
+                  isLast={index === recentTransactions.length - 1}
+                />
+              ))}
+            </View>
+          </View>
+        )}
         <View
           style={{
             backgroundColor: themeColors.card,
             borderRadius: 16,
+            marginBottom: 32,
           }}
         >
           {[
             {
-              name: "Transactions",
-              badge: 100,
-              path: "/(events)/[id]/transactions",
-            },
-            {
               name: "Team members",
-              badge: 100,
               path: "/(events)/[id]/team",
             },
             {
@@ -303,7 +346,6 @@ export default function Page() {
               }}
             >
               <ListItemText primary={button.name} />
-              <Text style={{ opacity: 0.6 }}>{button.badge}</Text>
               <Ionicons
                 name="chevron-forward"
                 size={24}


### PR DESCRIPTION
## Summary of the problem

The event details page currently shows a list of navigation options including a "Transactions" link, but doesn't provide a quick preview of recent transaction activity. This change adds a dedicated section displaying the 7 most recent transactions directly on the event details page, improving visibility into transaction history at a glance.

## Describe your changes

- Added a new "Recent transactions" section at the top of the event details page that displays the 7 most recent transactions
- Imported `TransactionWrapper` component to render individual transaction items in a consistent card-based layout
- Updated the Transaction type imports to include `ITransaction` for proper type casting
- Removed the "Transactions" navigation item from the menu list since transactions are now prominently featured above
- Removed badge counts from navigation items for a cleaner UI
- Added a "View all" link in the recent transactions header that navigates to the full transactions page
- Improved spacing with consistent gap styling in the main container

The recent transactions section only displays when there are transactions available, maintaining a clean interface for organizations with no transaction history.

## Checklist

- [x] Descriptive PR title
- [x] Easily digestible commits
- [x] CI passes
- [x] Tested by submitter before requesting review

https://claude.ai/code/session_012GKb9wHH6zkM1qve89Jzat