### PR TITLE
Clean up imports and remove unused navigation prop

### DIFF
--- a/app/(app)/(events)/[id]/account-numbers.tsx
+++ b/app/(app)/(events)/[id]/account-numbers.tsx
@@ -4,8 +4,7 @@ import PageTitle from "components/PageTitle";
 import { Text } from "components/Text";
 import * as Clipboard from "expo-clipboard";
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics";
-import { router, useNavigation } from "expo-router";
-import { useLocalSearchParams } from "expo-router/build/hooks";
+import { router, useLocalSearchParams, useNavigation } from "expo-router";
 import { useEffect, useState } from "react";
 import { Button, Linking, Platform, View } from "react-native";
 

--- a/app/(app)/cards/[id].tsx
+++ b/app/(app)/cards/[id].tsx
@@ -544,7 +544,6 @@ export default function CardPage() {
             isLoadingMore={isLoadingMore || false}
             card={card as Card}
             _card={card as Card}
-            navigation={navigation}
           />
         )}
       </ScrollView>

--- a/app/(app)/cards/card-grants/[id].tsx
+++ b/app/(app)/cards/card-grants/[id].tsx
@@ -50,7 +50,6 @@ import { normalizeSvg } from "@/utils/util";
 export default function Page() {
   const navigation = useNavigation();
   const { id: grantId, cardId } = useLocalSearchParams();
-  console.log(`Grant id: ${grantId}, Card id: ${cardId}`);
   const fullGrantId = grantId.startsWith("cdg_") ? grantId : `cdg_${grantId}`;
   const { colors: themeColors } = useTheme();
 
@@ -671,7 +670,6 @@ export default function Page() {
             isLoadingMore={isLoadingMore || false}
             card={card as Card}
             _card={card as Card}
-            navigation={navigation}
           />
         )}
       </ScrollView>


### PR DESCRIPTION
## Summary of the problem

Code cleanup to improve import organization and remove unused component props that are no longer needed.

## Describe your changes

- **Import consolidation**: Consolidated `useLocalSearchParams` import in `account-numbers.tsx` to use the main `expo-router` export instead of importing from the build hooks subpath
- **Removed debug logging**: Removed a `console.log` statement in the card grants page that was logging grant and card IDs
- **Removed unused prop**: Removed the `navigation` prop being passed to a component in two card-related pages (`card-grants/[id].tsx` and `cards/[id].tsx`) as it was not being utilized by the receiving component

These changes improve code cleanliness and maintainability without affecting functionality.

## Checklist

- [x] Descriptive PR title
- [x] CI passes
- [x] Tested by submitter before requesting review

https://claude.ai/code/session_01U1jxXSKDgKLWfcshpAHvrV