### PR TITLE
Communicate card locking to cardholders

### DIFF
--- a/src/components/CardLockBanner.tsx
+++ b/src/components/CardLockBanner.tsx
@@ -1,22 +1,27 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@react-navigation/native";
-import { memo } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import User from "../lib/types/User";
 import { useOfflineSWR } from "../lib/useOfflineSWR";
-import { palette } from "../styles/theme";
 
 // A standing notice shown while the cardholder's cards are locked for overdue
 // receipts. It is not dismissible: the state is only cleared by uploading a
 // receipt, which unlocks the cards within seconds. Mirrors the web banner.
-const CardLockBanner = memo(function CardLockBanner({
+//
+// Pass `user` to reuse a user already loaded by the parent; otherwise it is
+// fetched. `card_locking` is present only when the feature is enabled for the
+// current user, so the banner renders nothing for everyone else.
+export default function CardLockBanner({
   onPress,
+  user: userProp,
 }: {
-  onPress?: () => void;
+  onPress: () => void;
+  user?: User;
 }) {
   const { colors } = useTheme();
-  const { data: user } = useOfflineSWR<User>("user");
+  const { data: fetchedUser } = useOfflineSWR<User>(userProp ? null : "user");
+  const user = userProp ?? fetchedUser;
 
   const cardLocking = user?.card_locking;
   if (!cardLocking?.locked) {
@@ -24,7 +29,7 @@ const CardLockBanner = memo(function CardLockBanner({
   }
 
   const count = cardLocking.overdue_receipt_count;
-  const subtitle =
+  const lead =
     count > 0
       ? `Upload your ${count} overdue ${count === 1 ? "receipt" : "receipts"} and your cards work again in seconds.`
       : "Upload your overdue receipts and your cards work again in seconds.";
@@ -35,27 +40,25 @@ const CardLockBanner = memo(function CardLockBanner({
       accessibilityRole="button"
       style={({ pressed }) => [
         styles.container,
-        { backgroundColor: colors.card, borderColor: palette.primary },
-        pressed && onPress ? styles.pressed : null,
+        { backgroundColor: colors.card, borderColor: colors.primary },
+        pressed ? styles.pressed : null,
       ]}
     >
       <View style={styles.content}>
-        <Ionicons name="lock-closed" size={22} color={palette.primary} />
+        <Ionicons name="lock-closed" size={22} color={colors.primary} />
         <View style={styles.textContainer}>
-          <Text style={[styles.title, { color: palette.primary }]}>
+          <Text style={[styles.title, { color: colors.primary }]}>
             Your cards are locked
           </Text>
           <Text style={[styles.subtitle, { color: colors.text }]}>
-            {subtitle}
+            {lead} Recurring charges will keep failing until you upload.
           </Text>
         </View>
-        {onPress ? (
-          <Ionicons name="chevron-forward" size={18} color={colors.text} />
-        ) : null}
+        <Ionicons name="chevron-forward" size={18} color={colors.text} />
       </View>
     </Pressable>
   );
-});
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -94,5 +97,3 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
 });
-
-export default CardLockBanner;

--- a/src/components/CardLockBanner.tsx
+++ b/src/components/CardLockBanner.tsx
@@ -1,0 +1,98 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@react-navigation/native";
+import { memo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import User from "../lib/types/User";
+import { useOfflineSWR } from "../lib/useOfflineSWR";
+import { palette } from "../styles/theme";
+
+// A standing notice shown while the cardholder's cards are locked for overdue
+// receipts. It is not dismissible: the state is only cleared by uploading a
+// receipt, which unlocks the cards within seconds. Mirrors the web banner.
+const CardLockBanner = memo(function CardLockBanner({
+  onPress,
+}: {
+  onPress?: () => void;
+}) {
+  const { colors } = useTheme();
+  const { data: user } = useOfflineSWR<User>("user");
+
+  const cardLocking = user?.card_locking;
+  if (!cardLocking?.locked) {
+    return null;
+  }
+
+  const count = cardLocking.overdue_receipt_count;
+  const subtitle =
+    count > 0
+      ? `Upload your ${count} overdue ${count === 1 ? "receipt" : "receipts"} and your cards work again in seconds.`
+      : "Upload your overdue receipts and your cards work again in seconds.";
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      style={({ pressed }) => [
+        styles.container,
+        { backgroundColor: colors.card, borderColor: palette.primary },
+        pressed && onPress ? styles.pressed : null,
+      ]}
+    >
+      <View style={styles.content}>
+        <Ionicons name="lock-closed" size={22} color={palette.primary} />
+        <View style={styles.textContainer}>
+          <Text style={[styles.title, { color: palette.primary }]}>
+            Your cards are locked
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.text }]}>
+            {subtitle}
+          </Text>
+        </View>
+        {onPress ? (
+          <Ionicons name="chevron-forward" size={18} color={colors.text} />
+        ) : null}
+      </View>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 12,
+    borderRadius: 10,
+    marginBottom: 16,
+    borderWidth: 1.5,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+  content: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 2,
+    letterSpacing: -0.2,
+  },
+  subtitle: {
+    fontSize: 13,
+    opacity: 0.8,
+  },
+});
+
+export default CardLockBanner;

--- a/src/lib/types/User.ts
+++ b/src/lib/types/User.ts
@@ -23,6 +23,13 @@ export default interface User extends Omit<HcbApiObject<"usr">, "created_at"> {
     postal_code: string;
     country: string;
   };
+  // Present only when the card-locking receipt-compliance feature is enabled
+  // for the user. `locked` is true when their cards are currently locked for
+  // overdue receipts; upload a receipt to unlock.
+  card_locking?: {
+    locked: boolean;
+    overdue_receipt_count: number;
+  };
 }
 
 export interface OrgUser extends User {

--- a/src/pages/cards/card.tsx
+++ b/src/pages/cards/card.tsx
@@ -18,6 +18,7 @@ import {
 import { useSWRConfig } from "swr";
 
 import Button from "../../components/Button";
+import CardLockBanner from "../../components/CardLockBanner";
 import AddToWalletSection from "../../components/cards/AddToWalletSection";
 import CardDetails from "../../components/cards/CardDetails";
 import CardDisplay from "../../components/cards/CardDisplay";
@@ -502,6 +503,10 @@ export default function CardPage(
         scrollEventThrottle={400}
       >
         {cardError && <CardError error={cardError} onRetry={onRefresh} />}
+
+        <CardLockBanner
+          onPress={() => navigation.getParent()?.navigate("Receipts")}
+        />
 
         {card && (
           <CardDisplay

--- a/src/pages/cards/card.tsx
+++ b/src/pages/cards/card.tsx
@@ -1,5 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+import {
+  useBottomTabBarHeight,
+  BottomTabNavigationProp,
+} from "@react-navigation/bottom-tabs";
 import { useTheme, useFocusEffect } from "@react-navigation/native";
 import {
   NativeStackNavigationProp,
@@ -27,7 +30,10 @@ import CardSkeleton from "../../components/cards/CardSkeleton";
 import CardTransactions from "../../components/cards/CardTransactions";
 import ActivateCardModal from "../../components/cards/modals/ActivateCardModal";
 import useClient from "../../lib/client";
-import { CardsStackParamList } from "../../lib/NavigatorParamList";
+import {
+  CardsStackParamList,
+  TabParamList,
+} from "../../lib/NavigatorParamList";
 import useTransactions from "../../lib/organization/useTransactions";
 import Card from "../../lib/types/Card";
 import { OrganizationExpanded } from "../../lib/types/Organization";
@@ -504,9 +510,16 @@ export default function CardPage(
       >
         {cardError && <CardError error={cardError} onRetry={onRefresh} />}
 
-        <CardLockBanner
-          onPress={() => navigation.getParent()?.navigate("Receipts")}
-        />
+        {isCardholder && (
+          <CardLockBanner
+            user={user}
+            onPress={() =>
+              navigation
+                .getParent<BottomTabNavigationProp<TabParamList>>()
+                ?.navigate("Receipts", { screen: "MissingReceiptList" })
+            }
+          />
+        )}
 
         {card && (
           <CardDisplay

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+import {
+  useBottomTabBarHeight,
+  BottomTabNavigationProp,
+} from "@react-navigation/bottom-tabs";
 import { useFocusEffect } from "@react-navigation/native";
 import {
   NativeStackScreenProps,
@@ -28,7 +31,7 @@ import GrantInvite from "../components/organizations/GrantInvite";
 import { HomeLoadingSkeleton } from "../components/organizations/HomeLoadingSkeleton";
 import { NoOrganizationsEmptyState } from "../components/organizations/NoOrganizationsEmptyState";
 import PromoBanner from "../components/PromoBanner";
-import { StackParamList } from "../lib/NavigatorParamList";
+import { StackParamList, TabParamList } from "../lib/NavigatorParamList";
 import useReorderedOrgs from "../lib/organization/useReorderedOrgs";
 import GrantCard from "../lib/types/GrantCard";
 import Invitation from "../lib/types/Invitation";
@@ -325,7 +328,11 @@ export default function App({ navigation }: Props) {
         ListHeaderComponent={() => (
           <>
             <CardLockBanner
-              onPress={() => navigation.getParent()?.navigate("Receipts")}
+              onPress={() =>
+                navigation
+                  .getParent<BottomTabNavigationProp<TabParamList>>()
+                  ?.navigate("Receipts", { screen: "MissingReceiptList" })
+              }
             />
             <PromoBanner />
             {(invitations && invitations.length > 0) ||

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,7 @@ import ReorderableList, {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { preload, useSWRConfig } from "swr";
 
+import CardLockBanner from "../components/CardLockBanner";
 import Event from "../components/organizations/Event";
 import GrantInvite from "../components/organizations/GrantInvite";
 import { HomeLoadingSkeleton } from "../components/organizations/HomeLoadingSkeleton";
@@ -323,6 +324,9 @@ export default function App({ navigation }: Props) {
         ListEmptyComponent={() => <NoOrganizationsEmptyState />}
         ListHeaderComponent={() => (
           <>
+            <CardLockBanner
+              onPress={() => navigation.getParent()?.navigate("Receipts")}
+            />
             <PromoBanner />
             {(invitations && invitations.length > 0) ||
             (grantInvites && grantInvites.length > 0) ? (


### PR DESCRIPTION
## Summary of the problem

HCB is rolling out card locking: when a cardholder has a receipt more than ~7 days overdue, their cards are locked until they upload it. The mobile app has no way to tell a cardholder this is happening. A locked cardholder just sees their card decline at checkout with no explanation and no obvious way to fix it.

## Describe your changes

Adds a standing "your cards are locked" notice that tells cardholders why their cards stopped working and how to fix it.

- **New `CardLockBanner`** (`src/components/CardLockBanner.tsx`) shown on the home screen and the card detail screen. It renders only when the current user's cards are locked, and it is not dismissible, since the state clears only by uploading a receipt (which unlocks the cards within seconds). Tapping it jumps to the Receipts tab's missing-receipts list.
- **Copy mirrors the web surfaces:** uploading a receipt unlocks the cards in seconds, and recurring charges keep failing until the cardholder uploads.
- The card detail banner is shown only to the cardholder themselves, so a manager or admin viewing someone else's card does not see their own locked state attached to it.

**Depends on a backend change** exposing card-locking status on the API. `GET /api/v4/user` now returns, for the current user when the feature is enabled:

```json
"card_locking": { "locked": true, "overdue_receipt_count": 2 }
```

The banner shows nothing when that object is absent (feature off) or `locked` is false, so this is safe to merge and ships dark until the backend field is live.

## Checklist

- [x] Descriptive PR title
- [ ] Tag related issues so they auto-close on merge
- [x] Easily digestible commits
- [ ] CI passes
- [ ] Tested by submitter before requesting review

<!-- Draft: not yet run on a device/simulator against the live API field. TypeScript, ESLint, and Prettier all pass. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
